### PR TITLE
fix for updating credential

### DIFF
--- a/src/Arduino_NetworkConfigurator.h
+++ b/src/Arduino_NetworkConfigurator.h
@@ -162,6 +162,7 @@ private:
   ConnectionHandler *_connectionHandler;
   static inline models::NetworkSetting _networkSetting;
   bool _connectionHandlerIstantiated;
+  bool _configInProgress;
   ResetInput *_resetInput;
   LEDFeedbackClass *_ledFeedback;
   /* Timeout instances */


### PR DESCRIPTION
This PR fix the problem:
If the `AgentsManagerClass::update()` is called also outside the NetworkConfigurator class and the NetworkConfigurator is in the  `CONFIGURED` state, the NetworkConfigurator is no more able to detect when a new peer (Mobile app or FE) is connecting for changing credentials and, consequentially, to move to the state `UPDATING_CONFIG` when needed
