### PR TITLE
Use wifi fw version cbor encoder of CloudUtils

### DIFF
--- a/extras/test/src/test_provisioning_command_encode.cpp
+++ b/extras/test/src/test_provisioning_command_encode.cpp
@@ -209,33 +209,6 @@
     }
    }
 
-   WHEN("Encode a message with provisioning wifi fw version ")
-   {
-    WiFiFWVersionProvisioningMessage command;
-    command.c.id = ProvisioningMessageId::WiFiFWVersionProvisioningMessageId;
-    command.wifiFwVersion = "1.6.0";
-    uint8_t buffer[512];
-    size_t bytes_encoded = sizeof(buffer);
-
-    CBORMessageEncoder encoder;
-    MessageEncoder::Status err = encoder.encode((Message*)&command, buffer, bytes_encoded);
-
-    uint8_t expected_result[] = {
-    0xda, 0x00, 0x01, 0x20, 0x14, 0x81, 0x65, 0x31, 0x2E, 0x36, 0x2E, 0x30
-    };
-
-    // Test the encoding is
-    //DA 00012014     # tag(73748)
-    // 81             # array(1)
-    //   65           # text(5)
-    //     312E362E30 # "1.6.0"
-    THEN("The encoding is successful") {
-        REQUIRE(err == MessageEncoder::Status::Complete);
-        REQUIRE(bytes_encoded == sizeof(expected_result));
-        REQUIRE(memcmp(buffer, expected_result, sizeof(expected_result)) == 0);
-    }
-   }
-
    WHEN("Encode a message with provisioning sketch version ")
    {
     ProvSketchVersionProvisioningMessage command;

--- a/src/configuratorAgents/agents/boardConfigurationProtocol/CBORAdapter.cpp
+++ b/src/configuratorAgents/agents/boardConfigurationProtocol/CBORAdapter.cpp
@@ -87,9 +87,9 @@ bool CBORAdapter::wifiFWVersionToCBOR(const char *wifiFWVersion, uint8_t *data, 
   if(*len < CBOR_MIN_WIFI_FW_VERSION_LEN + strlen(wifiFWVersion)) {
     return false;
   }
-  WiFiFWVersionProvisioningMessage wifiFWVersionMsg;
-  wifiFWVersionMsg.c.id = ProvisioningMessageId::WiFiFWVersionProvisioningMessageId;
-  wifiFWVersionMsg.wifiFwVersion = wifiFWVersion;
+  VersionMessage wifiFWVersionMsg;
+  wifiFWVersionMsg.c.id = StandardMessageId::WiFiFWVersionMessageId;
+  wifiFWVersionMsg.params.version = wifiFWVersion;
 
   MessageEncoder::Status status = encoder.encode((Message *)&wifiFWVersionMsg, data, *len);
 

--- a/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/CBORInstances.h
+++ b/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/CBORInstances.h
@@ -8,7 +8,6 @@ static ListWifiNetworksProvisioningMessageEncoder   listWifiNetworksProvisioning
 static UniqueHardwareIdProvisioningMessageEncoder   uniqueHardwareIdProvisioningMessageEncoder;
 static JWTProvisioningMessageEncoder                jWTProvisioningMessageEncoder;
 static BLEMacAddressProvisioningMessageEncoder      bLEMacAddressProvisioningMessageEncoder;
-static WiFiFWVersionProvisioningMessageEncoder      wiFiFWVersionProvisioningMessageEncoder;
 static ProvSketchVersionProvisioningMessageEncoder  provSketchVersionProvisioningMessageEncoder;
 static NetConfigLibVersProvisioningMessageEncoder   netConfigLibVersProvisioningMessageEncoder;
 

--- a/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/Encoder.cpp
+++ b/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/Encoder.cpp
@@ -116,25 +116,6 @@ MessageEncoder::Status BLEMacAddressProvisioningMessageEncoder::encode(CborEncod
   return MessageEncoder::Status::Complete;
 }
 
-MessageEncoder::Status WiFiFWVersionProvisioningMessageEncoder::encode(CborEncoder* encoder, Message *msg) {
-  WiFiFWVersionProvisioningMessage * provisioningWiFiFWVersion = (WiFiFWVersionProvisioningMessage*) msg;
-  CborEncoder array_encoder;
-
-  if(cbor_encoder_create_array(encoder, &array_encoder, 1) != CborNoError) {
-    return MessageEncoder::Status::Error;
-  }
-
-  if(cbor_encode_text_stringz(&array_encoder, provisioningWiFiFWVersion->wifiFwVersion) != CborNoError) {
-    return MessageEncoder::Status::Error;
-  }
-
-  if(cbor_encoder_close_container(encoder, &array_encoder) != CborNoError) {
-    return MessageEncoder::Status::Error;
-  }
-
-  return MessageEncoder::Status::Complete;
-}
-
 MessageEncoder::Status ProvSketchVersionProvisioningMessageEncoder::encode(CborEncoder* encoder, Message *msg) {
   ProvSketchVersionProvisioningMessage * provisioningSketchVersion = (ProvSketchVersionProvisioningMessage*) msg;
   CborEncoder array_encoder;

--- a/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/Encoder.h
+++ b/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/Encoder.h
@@ -52,14 +52,6 @@ protected:
   MessageEncoder::Status encode(CborEncoder* encoder, Message *msg) override;
 };
 
-class WiFiFWVersionProvisioningMessageEncoder: public CBORMessageEncoderInterface {
-public:
-  WiFiFWVersionProvisioningMessageEncoder()
-  : CBORMessageEncoderInterface(CBORWiFiFWVersionProvisioningMessage, WiFiFWVersionProvisioningMessageId) {}
-protected:
-  MessageEncoder::Status encode(CborEncoder* encoder, Message *msg) override;
-};
-
 class ProvSketchVersionProvisioningMessageEncoder: public CBORMessageEncoderInterface {
   public:
   ProvSketchVersionProvisioningMessageEncoder()

--- a/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/ProvisioningMessage.h
+++ b/src/configuratorAgents/agents/boardConfigurationProtocol/cbor/ProvisioningMessage.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <Arduino_CBOR.h>
+#include <cbor/standards/StandardMessages.h>
 #include <ConnectionHandlerDefinitions.h>
 #include <connectionHandlerModels/settings.h>
 #include <configuratorAgents/NetworkOptionsDefinitions.h>
@@ -47,7 +48,6 @@ enum CBORProvisioningMessageTag: CBORTag {
   CBORUniqueHardwareIdProvisioningMessage   = 0x012010,
   CBORJWTProvisioningMessage                = 0x012011,
   CBORBLEMacAddressProvisioningMessage      = 0x012013,
-  CBORWiFiFWVersionProvisioningMessage      = 0x012014,
   CBORProvSketchVersionProvisioningMessage  = 0x012015,
   CBORNetConfigLibVersProvisioningMessage   = 0x012016,
 };
@@ -58,7 +58,6 @@ enum ProvisioningMessageId: MessageId {
   ListWifiNetworksProvisioningMessageId,
   UniqueHardwareIdProvisioningMessageId,
   BLEMacAddressProvisioningMessageId,
-  WiFiFWVersionProvisioningMessageId,
   ProvSketchVersionProvisioningMessageId,
   NetConfigLibVersProvisioningMessageId,
   JWTProvisioningMessageId,
@@ -113,13 +112,6 @@ struct BLEMacAddressProvisioningMessage {
   ProvisioningMessage c;
   struct {
     uint8_t macAddress[BLE_MAC_ADDRESS_SIZE];
-  };
-};
-
-struct WiFiFWVersionProvisioningMessage {
-  ProvisioningMessage c;
-  struct {
-    const char *wifiFwVersion; //The payload is a string.
   };
 };
 


### PR DESCRIPTION
### Changes:

- use WiFi FW version cbor encoder from CloudUtils 
- remove the internal definition

This PR relies on https://github.com/arduino-libraries/Arduino_CloudUtils/pull/33