### PR TITLE
LedFeedbackClass fix led pin not initialized

### DIFF
--- a/src/utility/LEDFeedback.cpp
+++ b/src/utility/LEDFeedback.cpp
@@ -180,6 +180,7 @@ void LEDFeedbackClass::setMode(LEDFeedbackMode mode) {
     case LEDFeedbackMode::NONE:
       {
         _ledChangeInterval = 0;
+        turnOFF();
         #ifdef BOARD_HAS_LED_MATRIX
           ledMatrixAnimationHandler.clear();
         #endif
@@ -288,14 +289,11 @@ void LEDFeedbackClass::restart() {
 }
 
 void LEDFeedbackClass::update() {
-  if(stopped) {
+  if(stopped || _mode == LEDFeedbackMode::NONE) {
     return;
   }
 
-  if(_ledChangeInterval == 0) {
-    turnOFF();
-    return;
-  } else if (_ledChangeInterval == ALWAYS_ON_INTERVAL) {
+  if (_ledChangeInterval == ALWAYS_ON_INTERVAL) {
     turnON();
     return;
   }
@@ -330,11 +328,13 @@ void LEDFeedbackClass::update() {
 }
 
 void LEDFeedbackClass::turnOFF() {
-#ifdef BOARD_USE_NINA
-  WiFiDrv::digitalWrite(_ledPin, LED_OFF);
-#else
-  digitalWrite(_ledPin, LED_OFF);
-#endif
+  if(_ledPin != INVALID_LED_PIN) {
+  #ifdef BOARD_USE_NINA
+    WiFiDrv::digitalWrite(_ledPin, LED_OFF);
+  #else
+    digitalWrite(_ledPin, LED_OFF);
+  #endif
+  }
 #ifdef BOARD_HAS_LED_MATRIX
   if(_framePtr != nullptr){
     ledMatrixAnimationHandler.clear();
@@ -345,11 +345,13 @@ void LEDFeedbackClass::turnOFF() {
 }
 
 void LEDFeedbackClass::turnON() {
-#ifdef BOARD_USE_NINA
-  WiFiDrv::digitalWrite(_ledPin, LED_ON);
-#else
-  digitalWrite(_ledPin, LED_ON);
-#endif
+  if(_ledPin != INVALID_LED_PIN) {
+  #ifdef BOARD_USE_NINA
+    WiFiDrv::digitalWrite(_ledPin, LED_ON);
+  #else
+    digitalWrite(_ledPin, LED_ON);
+  #endif
+  }
 #ifdef BOARD_HAS_LED_MATRIX
   if(_framePtr != nullptr){
     ledMatrixAnimationHandler.loadFrame(_framePtr);

--- a/src/utility/LEDFeedback.h
+++ b/src/utility/LEDFeedback.h
@@ -8,7 +8,7 @@
 #pragma once
 #include "Arduino.h"
 
-
+#define INVALID_LED_PIN -1
 
 class LEDFeedbackClass {
 public:
@@ -37,8 +37,8 @@ private:
     uint32_t _lastUpdate = 0;
     uint32_t _count = 0;
     bool _ledState = false;
-    uint16_t _ledPin = 0;
+    int _ledPin = INVALID_LED_PIN;
     uint32_t* _framePtr = nullptr;
-    int32_t _ledChangeInterval = 500;
+    int32_t _ledChangeInterval = 0;
     bool stopped = false;
 };


### PR DESCRIPTION
### Issue
It has been reported a malfunction of the OPTA relay number 1 that was continously turning on and off. 
The device was running a Cloud Sketch 2.0 with the NetworkConfigurator enabled.

After investigation the problem was found on a not properly initialization of the pin for the feedback led when no feedback mode is selected.

### Changes

- Initialize the `_ledPin` with an invalid value and check its value before setting it `ON` or `OFF`
- turn off the led when the mode `NONE` is selected